### PR TITLE
Fix leaderboard scroll and improve UX

### DIFF
--- a/script.js
+++ b/script.js
@@ -117,9 +117,13 @@ window.onload = () => {
   loadLeaderboard();
 };
 
-document.getElementById('leaderboardList').addEventListener('scroll', () => {
-  const list = document.getElementById('leaderboardList');
-  if (list.scrollTop + list.clientHeight >= list.scrollHeight - 10) {
+const leaderboardContainer = document.getElementById('leaderboard');
+leaderboardContainer.addEventListener('scroll', () => {
+  if (
+    leaderboardContainer.scrollTop +
+      leaderboardContainer.clientHeight >=
+    leaderboardContainer.scrollHeight - 10
+  ) {
     loadLeaderboard();
   }
 });

--- a/style.css
+++ b/style.css
@@ -57,23 +57,25 @@ body.dark h1 {
 }
 
 #xpInput {
-  padding: 0.4rem 0.6rem;
+  padding: 0.6rem 1rem;
   border-radius: 6px;
   border: 1px solid #ccc;
-  min-width: 250px;
+  min-width: 300px;
+  font-size: 1rem;
 }
 
-button {
-  padding: 0.4rem 0.8rem;
+#search button {
+  padding: 0.6rem 1rem;
   background: #5a3223;
   color: #fff;
   border: none;
   border-radius: 6px;
   cursor: pointer;
   transition: 0.2s;
+  font-size: 1rem;
 }
 
-button:hover {
+#search button:hover {
   background: #3d2217;
 }
 
@@ -106,6 +108,10 @@ body.dark .stats-box {
   font-size: 1.2rem;
   font-weight: bold;
   text-align: center;
+}
+
+body.dark #realMooseMessage {
+  color: white;
 }
 
 /* LEADERBOARD */


### PR DESCRIPTION
## Summary
- enlarge the input field and search button
- show Real Moose message in white text on dark theme
- load more leaderboard entries while scrolling

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875866429d483319c47288af3fdad78