### PR TITLE
Improve UI styling for XP calculator

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,10 +39,14 @@ main {
 
 h1 {
   text-align: center;
-  margin-top: 10px;
+  margin: 10px auto;
   font-size: 2rem;
   font-weight: 700;
-  color: #000;
+  background: #5a3223;
+  color: #fff;
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  display: inline-block;
 }
 
 body.dark h1 {
@@ -94,8 +98,12 @@ body.dark h1 {
   background: rgba(255, 255, 255, 0.9);
   padding: 1rem;
   border-radius: 12px;
-  width: 250px;
+  width: 300px;
   backdrop-filter: blur(8px);
+}
+
+.stats-box:empty {
+  display: none;
 }
 
 body.dark .stats-box {
@@ -108,10 +116,21 @@ body.dark .stats-box {
   font-size: 1.2rem;
   font-weight: bold;
   text-align: center;
+  background: #5a3223;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  display: inline-block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+#realMooseMessage:empty {
+  display: none;
 }
 
 body.dark #realMooseMessage {
-  color: white;
+  color: #fff;
 }
 
 /* LEADERBOARD */


### PR DESCRIPTION
## Summary
- style the header with a brown rounded background
- enlarge stats boxes and hide them when empty
- style the real moose message with brown rounded background and auto-hide when empty

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68758961dec4833192f87230b3aa8293