### PR TITLE
Update stats and progress UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ async function calculateXP() {
   const username = document.getElementById('xpInput').value.trim();
   const topStats = document.getElementById('topStats');
   const bottomStats = document.getElementById('bottomStats');
+  const statsWrapper = document.getElementById('statsWrapper');
   const message = document.getElementById('realMooseMessage');
   topStats.innerHTML = '';
   bottomStats.innerHTML = '';
@@ -45,6 +46,7 @@ async function calculateXP() {
     `;
 
     topStats.innerHTML = statsHTML;
+    statsWrapper.classList.remove('center');
 
     let target = 0, prev = 0, reward = '';
     for (let i = 0; i < levels.length; i++) {
@@ -67,16 +69,29 @@ async function calculateXP() {
     const hours = Math.floor((minutesLeft % 1440) / 60);
     const minutes = minutesLeft % 60;
 
+    const progressPercent = Math.max(
+      0,
+      Math.min(100, ((xp - prev) / (target - prev)) * 100)
+    );
     const progressHTML = `
       <h3>🔑 Progress</h3>
       <p><strong>To reach:</strong> ${reward}</p>
       <p><strong>XP left:</strong> ${left.toLocaleString()}</p>
       <p><strong>Time:</strong> ${days}d ${hours}h ${minutes}m</p>
+      <div class="progress-container">
+        <div class="progress-bar" style="width: ${progressPercent}%"></div>
+      </div>
     `;
 
     bottomStats.innerHTML = progressHTML;
+    if (!topStats.innerHTML.trim() && progressHTML) {
+      statsWrapper.classList.add('center');
+    } else {
+      statsWrapper.classList.remove('center');
+    }
   } catch (e) {
     topStats.innerHTML = `<div class="error">❌ ${e.message}</div>`;
+    statsWrapper.classList.remove('center');
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -101,12 +101,23 @@ body.dark h1 {
   align-items: flex-end;
 }
 
+#statsWrapper.center {
+  right: 50%;
+  transform: translateX(50%);
+  align-items: center;
+}
+
 .stats-box {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(245, 245, 220, 0.9);
   padding: 1rem;
   border-radius: 12px;
   width: 300px;
+  border: 2px solid #5a3223;
   backdrop-filter: blur(8px);
+}
+
+#topStats {
+  width: 350px;
 }
 
 .stats-box:empty {
@@ -116,6 +127,7 @@ body.dark h1 {
 body.dark .stats-box {
   background: rgba(0, 0, 0, 0.65);
   color: white;
+  border: 2px solid #5a3223;
 }
 
 #realMooseMessage {
@@ -147,16 +159,18 @@ body.dark #realMooseMessage {
   left: 20px;
   width: 300px;
   height: calc(100% - 80px);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(245, 245, 220, 0.9);
   border-radius: 12px;
   padding: 1rem;
   overflow-y: auto;
+  border: 2px solid #5a3223;
   backdrop-filter: blur(8px);
 }
 
 body.dark #leaderboard {
   background: rgba(0, 0, 0, 0.65);
   color: white;
+  border: 2px solid #5a3223;
 }
 
 #leaderboard h3 {
@@ -171,16 +185,18 @@ body.dark #leaderboard {
 }
 
 #leaderboardList li {
-  background: #f5f5f5;
+  background: #f5f5dc;
   padding: 0.6rem;
   border-radius: 8px;
   font-size: 0.9rem;
+  border: 1px solid #5a3223;
   box-shadow: 0 0 4px rgba(0,0,0,0.05);
 }
 
 body.dark #leaderboardList li {
   background: #2d2d2d;
   color: white;
+  border: 1px solid #5a3223;
 }
 
 /* THEME SWITCH */
@@ -211,4 +227,19 @@ body.dark #leaderboardList li {
   padding: 0.5rem;
   border-radius: 6px;
   margin-top: 1rem;
+}
+
+.progress-container {
+  width: 100%;
+  height: 10px;
+  background: #ddd;
+  border-radius: 5px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.progress-bar {
+  height: 100%;
+  background: #5a3223;
+  width: 0;
 }


### PR DESCRIPTION
## Summary
- add centering mode for stats wrapper
- style stats and leaderboard panels beige with brown borders
- enlarge the user stats box
- add progress bar and centering logic in script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876089a01c4833180f0a6110d8433bf