### PR TITLE
Center progress block

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,12 +27,11 @@
         <button onclick="calculateXP()">Search XP</button>
       </div>
       <div id="realMooseMessage"></div>
+      <div id="statsWrapper">
+        <div id="topStats" class="stats-box"></div>
+        <div id="bottomStats" class="stats-box"></div>
+      </div>
     </div>
-
-  <div id="statsWrapper">
-    <div id="topStats" class="stats-box"></div>
-    <div id="bottomStats" class="stats-box"></div>
-  </div>
 
   <div class="theme-toggle">
     <button id="themeSwitch">🌙 Dark Mode</button>

--- a/style.css
+++ b/style.css
@@ -92,18 +92,15 @@ body.dark h1 {
 
 /* STATS & PROGRESS */
 #statsWrapper {
-  position: absolute;
-  right: 20px;
-  top: 100px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  align-items: flex-end;
+  align-items: center;
+  width: 100%;
+  margin-top: 1rem;
 }
 
 #statsWrapper.center {
-  right: 50%;
-  transform: translateX(50%);
   align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- move stats wrapper inside main container
- style stats wrapper so progress appears centered beneath nickname input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68760edd27cc8331a23db36cdad04dba