### PR TITLE
Add mobile-friendly slider layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,23 +15,29 @@
 <body>
   <div id="background"></div>
 
-  <div id="leaderboard">
-    <h3>🏆 Leaderboard</h3>
-    <ul id="leaderboardList"></ul>
-  </div>
+  <div id="slider">
+    <section id="leaderboardSlide" class="slide">
+      <div id="leaderboard">
+        <h3>🏆 Leaderboard</h3>
+        <ul id="leaderboardList"></ul>
+      </div>
+    </section>
 
-    <div class="container" id="mainContainer">
-      <h1>XP Calculator</h1>
-      <div id="search">
-        <input type="text" id="xpInput" placeholder="Enter your Discord name" />
-        <button onclick="calculateXP()">Search XP</button>
+    <section id="mainSlide" class="slide">
+      <div class="container" id="mainContainer">
+        <h1>XP Calculator</h1>
+        <div id="search">
+          <input type="text" id="xpInput" placeholder="Enter your Discord name" />
+          <button onclick="calculateXP()">Search XP</button>
+        </div>
+        <div id="realMooseMessage"></div>
+        <div id="statsWrapper">
+          <div id="topStats" class="stats-box"></div>
+          <div id="bottomStats" class="stats-box"></div>
+        </div>
       </div>
-      <div id="realMooseMessage"></div>
-      <div id="statsWrapper">
-        <div id="topStats" class="stats-box"></div>
-        <div id="bottomStats" class="stats-box"></div>
-      </div>
-    </div>
+    </section>
+  </div>
 
   <div class="theme-toggle">
     <button id="themeSwitch">🌙 Dark Mode</button>

--- a/style.css
+++ b/style.css
@@ -240,3 +240,43 @@ body.dark #leaderboardList li {
   background: #5a3223;
   width: 0;
 }
+
+/* SLIDER (mobile) */
+#slider {
+  display: flex;
+  height: 100%;
+}
+
+.slide {
+  width: 100%;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    overflow: hidden;
+  }
+
+  #slider {
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+  }
+
+  .slide {
+    scroll-snap-align: start;
+  }
+
+  #leaderboard {
+    position: static;
+    width: 100%;
+    height: auto;
+    margin-bottom: 1rem;
+  }
+
+  #themeSwitch {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Summary
- wrap main content and leaderboard in slider sections
- implement slider styles with scroll-snap for mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68763128d67483318a9bd6890e61238f